### PR TITLE
Provisioning K8s clusters with kubespray for latest stable and latest ci-cross K8s builds (promote to dev)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -52,6 +52,14 @@ Provisioning:
     - pushd /k8s-infra
     - /k8s-infra/bin/k8sinfra generate_config --arch="$ARCH" --release-type="$PIPELINE_RELEASE_TYPE" --infra-job="$INFRA_PIPELINE" -o /tmp/cluster.yml
     - /k8s-infra/bin/k8sinfra provision --config-file '/tmp/cluster.yml'
+    - export KUBECONFIG=/k8s-infra/data/mycluster/artifacts/admin.conf
+    - kubectl create -f ./manifests/helm-rbac.yml
+    - >
+      if [ "$ARCH" = "arm64" ]; then
+        helm init --service-account tiller --tiller-image=jessestuart/tiller --override spec.selector.matchLabels.'name'='tiller',spec.selector.matchLabels.'app'='helm' --output yaml | sed 's@apiVersion: extensions/v1beta1@apiVersion: apps/v1@' | kubectl apply -f -
+      else
+        helm init --service-account tiller --override spec.selector.matchLabels.'name'='tiller',spec.selector.matchLabels.'app'='helm' --output yaml | sed 's@apiVersion: extensions/v1beta1@apiVersion: apps/v1@' | kubectl apply -f -
+      fi
     - popd
     - mkdir ./data
     - cp /tmp/cluster.yml ./data

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -53,9 +53,9 @@ Provisioning:
     - /k8s-infra/bin/k8sinfra generate_config --arch="$ARCH" --release-type="$PIPELINE_RELEASE_TYPE" --infra-job="$INFRA_PIPELINE" -o /tmp/cluster.yml
     - /k8s-infra/bin/k8sinfra provision --config-file '/tmp/cluster.yml'
     - export KUBECONFIG=/k8s-infra/data/mycluster/artifacts/admin.conf
-    - kubectl create -f ./manifests/helm-rbac.yml
     - >
       if [ "$ARCH" = "arm64" ]; then
+        kubectl create -f ./manifests/helm-rbac.yml
         helm init --service-account tiller --tiller-image=jessestuart/tiller --override spec.selector.matchLabels.'name'='tiller',spec.selector.matchLabels.'app'='helm' --output yaml | sed 's@apiVersion: extensions/v1beta1@apiVersion: apps/v1@' | kubectl apply -f -
       else
         helm init --service-account tiller --override spec.selector.matchLabels.'name'='tiller',spec.selector.matchLabels.'app'='helm' --output yaml | sed 's@apiVersion: extensions/v1beta1@apiVersion: apps/v1@' | kubectl apply -f -

--- a/Dockerfile.deps
+++ b/Dockerfile.deps
@@ -120,6 +120,11 @@ RUN mkdir -p "$GEM_HOME" && chmod 777 "$GEM_HOME"
 #      stable" \
 #      && apt update -y && apt-get install docker-ce -y
 
+# Helm 
+ARG HELM_VERSION=2.14.3
+RUN curl -L http://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-linux-amd64.tar.gz | tar zxv -C /tmp
+RUN mv /tmp/linux-amd64/helm /usr/local/bin/
+
 # Kubectl
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.14.4/bin/linux/amd64/kubectl \
     && chmod a+x kubectl && cp kubectl /usr/local/bin/kubectl

--- a/Dockerfile.deps
+++ b/Dockerfile.deps
@@ -121,8 +121,9 @@ RUN mkdir -p "$GEM_HOME" && chmod 777 "$GEM_HOME"
 #      && apt update -y && apt-get install docker-ce -y
 
 # Helm 
-ARG HELM_VERSION=2.14.3
-RUN curl -L http://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-linux-amd64.tar.gz | tar zxv -C /tmp
+ARG VERSION=v2.14.3
+ARG FILENAME=helm-${VERSION}-linux-amd64.tar.gz
+RUN curl -L http://storage.googleapis.com/kubernetes-helm/${FILENAME} | tar zxv -C /tmp
 RUN mv /tmp/linux-amd64/helm /usr/local/bin/
 
 # Kubectl

--- a/bin/kubespray-integration.rb
+++ b/bin/kubespray-integration.rb
@@ -141,8 +141,6 @@ all:
     hyperkube_binary_checksum: <%= @cluster_hash['k8s_infra']['hyperkube_binary_checksum'] %>
     kubeadm_download_url: <%= @cluster_hash['k8s_infra']['kubeadm_download_url'] %>
     kubeadm_binary_checksum: <%= @cluster_hash['k8s_infra']['kubeadm_binary_checksum'] %>
-    helm_enabled: true
-    helm_deployment_type: host
   hosts:
     <%- @cluster_hash['k8s_infra']['nodes'].each_with_index do |x, index| -%>
     node<%=index %>:

--- a/bin/kubespray-integration.rb
+++ b/bin/kubespray-integration.rb
@@ -141,6 +141,8 @@ all:
     hyperkube_binary_checksum: <%= @cluster_hash['k8s_infra']['hyperkube_binary_checksum'] %>
     kubeadm_download_url: <%= @cluster_hash['k8s_infra']['kubeadm_download_url'] %>
     kubeadm_binary_checksum: <%= @cluster_hash['k8s_infra']['kubeadm_binary_checksum'] %>
+    helm_enabled: true
+    helm_deployment_type: host
   hosts:
     <%- @cluster_hash['k8s_infra']['nodes'].each_with_index do |x, index| -%>
     node<%=index %>:

--- a/manifests/helm-rbac.yml
+++ b/manifests/helm-rbac.yml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tiller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: tiller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: tiller
+    namespace: kube-system


### PR DESCRIPTION
## Description

:white_check_mark: Support [kubespray](https://github.com/kubernetes-sigs/kubespray) provisioning and enable [containerd](https://github.com/containerd/containerd)
:wheel_of_dharma: Support kubernetes from sig-testing/sig-release
- [latest stable release artifact](https://storage.googleapis.com/kubernetes-release/release/stable.txt)
- [latest ci cross build](https://storage.googleapis.com/kubernetes-release-dev/ci-cross/latest.txt)

issues:
- crosscloudci/crosscloudci#181
- vulk/cncf_ci#265


## Motivation and Context


## How Has This Been Tested?
* [ ]  Covered by existing integration testing
* [ ]  Added integration testing to cover
* [x] Tested with [trigger client](https://github.com/crosscloudci/crosscloudci-trigger) against 
   * [x] cidev.cncf.ci
   * [ ] dev.cncf.ci
   * [ ] staging.cncf.ci
   * [ ] cncf.ci (production)
* [x]  Tested locally
* [ ]  Have not tested

## Types of changes
* [ ]  Bug fix (non-breaking change which fixes an issue)
* [x]  New feature (non-breaking change which adds functionality)
* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
 
## Checklist:
* [x]  My change requires a change to the documentation.
* [ ]  I have updated the documentation accordingly.