### PR TITLE
BUGFIX: Use kubespray to deploy helm for amd64 vulk/cncf_ci#265

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,8 +57,6 @@ Provisioning:
       if [ "$ARCH" = "arm64" ]; then
         kubectl create -f ./manifests/helm-rbac.yml
         helm init --service-account tiller --tiller-image=jessestuart/tiller --override spec.selector.matchLabels.'name'='tiller',spec.selector.matchLabels.'app'='helm' --output yaml | sed 's@apiVersion: extensions/v1beta1@apiVersion: apps/v1@' | kubectl apply -f -
-      else
-        helm init --service-account tiller --override spec.selector.matchLabels.'name'='tiller',spec.selector.matchLabels.'app'='helm' --output yaml | sed 's@apiVersion: extensions/v1beta1@apiVersion: apps/v1@' | kubectl apply -f -
       fi
     - popd
     - mkdir ./data

--- a/bin/kubespray-integration.rb
+++ b/bin/kubespray-integration.rb
@@ -141,6 +141,10 @@ all:
     hyperkube_binary_checksum: <%= @cluster_hash['k8s_infra']['hyperkube_binary_checksum'] %>
     kubeadm_download_url: <%= @cluster_hash['k8s_infra']['kubeadm_download_url'] %>
     kubeadm_binary_checksum: <%= @cluster_hash['k8s_infra']['kubeadm_binary_checksum'] %>
+    <%- if @cluster_hash['k8s_infra']['arch']=='amd64' -%>
+    helm_enabled: true
+    helm_deployment_type: host
+    <%- end -%>
   hosts:
     <%- @cluster_hash['k8s_infra']['nodes'].each_with_index do |x, index| -%>
     node<%=index %>:


### PR DESCRIPTION
## Description

Deploy helm (tiller) to the K8s cluster using kubespray for amd64 and continue manually installing for arm.

issues:
- crosscloudci/crosscloudci#181
- vulk/cncf_ci#265


## Motivation and Context

Kubespray supports installing helm as an option but only works for amd64.  Manually installing helm with multi-arch nightly build from https://github.com/jessestuart/tiller-multiarch works for Arm.



## How Has This Been Tested?
* [ ]  Covered by existing integration testing
* [ ]  Added integration testing to cover
* [x] Tested with [trigger client](https://github.com/crosscloudci/crosscloudci-trigger) against 
   * [x] cidev.cncf.ci
   * [ ] dev.cncf.ci
   * [ ] staging.cncf.ci
   * [ ] cncf.ci (production)
* [x]  Tested locally
* [ ]  Have not tested

## Types of changes
* [ ]  Bug fix (non-breaking change which fixes an issue)
* [x]  New feature (non-breaking change which adds functionality)
* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
 
## Checklist:
* [x]  My change requires a change to the documentation.
* [ ]  I have updated the documentation accordingly.