### PR TITLE
BUGFIX: Fixes bug causing HEAD deploys to fail. (production)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,6 +54,7 @@ Provisioning:
     - /k8s-infra/bin/k8sinfra provision --config-file '/tmp/cluster.yml'
     - export KUBECONFIG=/k8s-infra/data/mycluster/artifacts/admin.conf
     - >
+      # Kubespray supports Helm (tiller) for amd64 only. Manually installing for Arm
       if [ "$ARCH" = "arm64" ]; then
         kubectl create -f ./manifests/helm-rbac.yml
         helm init --service-account tiller --tiller-image=jessestuart/tiller --override spec.selector.matchLabels.'name'='tiller',spec.selector.matchLabels.'app'='helm' --output yaml | sed 's@apiVersion: extensions/v1beta1@apiVersion: apps/v1@' | kubectl apply -f -

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,10 +54,11 @@ Provisioning:
     - /k8s-infra/bin/k8sinfra provision --config-file '/tmp/cluster.yml'
     - export KUBECONFIG=/k8s-infra/data/mycluster/artifacts/admin.conf
     - >
-      # Kubespray supports Helm (tiller) for amd64 only. Manually installing for Arm
       if [ "$ARCH" == "arm64" ]; then
-        kubectl apply -f ./manifests/helm-rbac.yml
-        helm init --service-account tiller --tiller-image=jessestuart/tiller --override spec.selector.matchLabels.'name'='tiller',spec.selector.matchLabels.'app'='helm' --output yaml | sed 's@apiVersion: extensions/v1beta1@apiVersion: apps/v1@' | kubectl apply -f -
+         kubectl apply -f ./manifests/helm-rbac.yml
+         helm init --service-account tiller --tiller-image=jessestuart/tiller --override spec.selector.matchLabels.'name'='tiller',spec.selector.matchLabels.'app'='helm' --output yaml | sed 's@apiVersion: extensions/v1beta1@apiVersion: apps/v1@' | kubectl apply -f -
+      else
+         echo 'skip helm deploy when ARCH is amd64, Kubespray will install helm.'
       fi
     - popd
     - mkdir ./data

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,8 +55,8 @@ Provisioning:
     - export KUBECONFIG=/k8s-infra/data/mycluster/artifacts/admin.conf
     - >
       # Kubespray supports Helm (tiller) for amd64 only. Manually installing for Arm
-      if [ "$ARCH" = "arm64" ]; then
-        kubectl create -f ./manifests/helm-rbac.yml
+      if [ "$ARCH" == "arm64" ]; then
+        kubectl apply -f ./manifests/helm-rbac.yml
         helm init --service-account tiller --tiller-image=jessestuart/tiller --override spec.selector.matchLabels.'name'='tiller',spec.selector.matchLabels.'app'='helm' --output yaml | sed 's@apiVersion: extensions/v1beta1@apiVersion: apps/v1@' | kubectl apply -f -
       fi
     - popd

--- a/bin/kubespray-integration.rb
+++ b/bin/kubespray-integration.rb
@@ -132,6 +132,7 @@ all:
     nodelocaldns_image_repo: gcr.io/google-containers/k8s-dns-node-cache
     dnsautoscaler_image_repo: gcr.io/google-containers/cluster-proportional-autoscaler-<%= @cluster_hash['k8s_infra']['arch'] %>
     kube_version: <%= @cluster_hash['k8s_infra']['k8s_release'] %>
+    kube_major_version: <%= @cluster_hash['k8s_infra']['stable_k8s_release'].split(".").take(2).join(".") %>
     etcd_deployment_type: host
     container_manager: containerd
     download_container: False


### PR DESCRIPTION
## Description
1. Fixes bug causing HEAD deploys to fail.

## Context
Kubespray now depends on a new attribute being set "kube_major_version" and by default, it uses kube_version to derive it. This means that HEAD deploys will fail because kube_version will be set to a HEAD release and the logic used to create the kube_major_version attribute doesn't support this.


Issues:

## How Has This Been Tested?
* [x]  Covered by existing integration testing
* [ ]  Added integration testing to cover
* [x] Tested with [trigger client](https://github.com/crosscloudci/crosscloudci-trigger) against 
   * [x] cidev.cncf.ci
   * [ ] dev.cncf.ci
   * [x] staging.cncf.ci
   * [ ] cncf.ci (production)
* [x]  Tested locally
* [ ]  Have not tested

## Types of changes
* [x]  Bug fix (non-breaking change which fixes an issue)
* [ ]  New feature (non-breaking change which adds functionality)
* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
 
## Checklist:
* [ ]  My change requires a change to the documentation.
* [ ]  I have updated the documentation accordingly.
* [x] No updates required.