### PR TITLE
Fix provisioning failures for Kubernetes HEAD arm64/amd64(dev)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,6 +54,7 @@ Provisioning:
     - /k8s-infra/bin/k8sinfra provision --config-file '/tmp/cluster.yml'
     - export KUBECONFIG=/k8s-infra/data/mycluster/artifacts/admin.conf
     - >
+      # Kubespray supports Helm (tiller) for amd64 only. Manually installing for Arm
       if [ "$ARCH" = "arm64" ]; then
         kubectl create -f ./manifests/helm-rbac.yml
         helm init --service-account tiller --tiller-image=jessestuart/tiller --override spec.selector.matchLabels.'name'='tiller',spec.selector.matchLabels.'app'='helm' --output yaml | sed 's@apiVersion: extensions/v1beta1@apiVersion: apps/v1@' | kubectl apply -f -

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,10 +54,11 @@ Provisioning:
     - /k8s-infra/bin/k8sinfra provision --config-file '/tmp/cluster.yml'
     - export KUBECONFIG=/k8s-infra/data/mycluster/artifacts/admin.conf
     - >
-      # Kubespray supports Helm (tiller) for amd64 only. Manually installing for Arm
       if [ "$ARCH" == "arm64" ]; then
-        kubectl apply -f ./manifests/helm-rbac.yml
-        helm init --service-account tiller --tiller-image=jessestuart/tiller --override spec.selector.matchLabels.'name'='tiller',spec.selector.matchLabels.'app'='helm' --output yaml | sed 's@apiVersion: extensions/v1beta1@apiVersion: apps/v1@' | kubectl apply -f -
+         kubectl apply -f ./manifests/helm-rbac.yml
+         helm init --service-account tiller --tiller-image=jessestuart/tiller --override spec.selector.matchLabels.'name'='tiller',spec.selector.matchLabels.'app'='helm' --output yaml | sed 's@apiVersion: extensions/v1beta1@apiVersion: apps/v1@' | kubectl apply -f -
+      else
+         echo 'skip helm deploy when ARCH is amd64, Kubespray will install helm.'
       fi
     - popd
     - mkdir ./data

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,8 +55,8 @@ Provisioning:
     - export KUBECONFIG=/k8s-infra/data/mycluster/artifacts/admin.conf
     - >
       # Kubespray supports Helm (tiller) for amd64 only. Manually installing for Arm
-      if [ "$ARCH" = "arm64" ]; then
-        kubectl create -f ./manifests/helm-rbac.yml
+      if [ "$ARCH" == "arm64" ]; then
+        kubectl apply -f ./manifests/helm-rbac.yml
         helm init --service-account tiller --tiller-image=jessestuart/tiller --override spec.selector.matchLabels.'name'='tiller',spec.selector.matchLabels.'app'='helm' --output yaml | sed 's@apiVersion: extensions/v1beta1@apiVersion: apps/v1@' | kubectl apply -f -
       fi
     - popd

--- a/Dockerfile.deps
+++ b/Dockerfile.deps
@@ -128,4 +128,4 @@ RUN mv /tmp/linux-amd64/helm /usr/local/bin/
 
 # Kubectl
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.14.4/bin/linux/amd64/kubectl \
-    && chmod a+x kubectl && cp kubectl /usr/local/bin/kubectl
+    && chmod a+x kubectl && mv kubectl /usr/local/bin/kubectl

--- a/bin/k8sutils.rb
+++ b/bin/k8sutils.rb
@@ -3,8 +3,8 @@ require 'rest-client'
 
 class K8sUtils
   STABLE_RELEASE_URL="https://storage.googleapis.com/kubernetes-release/release/stable.txt"
-  HEAD_RELEASE_URL="https://storage.googleapis.com/kubernetes-release-dev/ci/latest.txt"
-  NIGHTLY_RELEASE_URL="https://storage.googleapis.com/kubernetes-release-dev/ci-cross/latest.txt"
+  HEAD_RELEASE_URL="https://storage.googleapis.com/kubernetes-release-dev/ci/k8s-master.txt"
+  HEAD_RELEASE_FAST_URL="https://storage.googleapis.com/kubernetes-release-dev/ci/latest.txt"
 
   def self.kubernetes_release(release_type)
     release_url = case release_type
@@ -15,9 +15,9 @@ class K8sUtils
                   when "stable/arm64"
                     "#{STABLE_RELEASE_URL}"
                   when "head/amd64"
-                    "#{NIGHTLY_RELEASE_URL}"
+                    "#{HEAD_RELEASE_URL}"
                   when "head/arm64"
-                    "#{NIGHTLY_RELEASE_URL}"
+                    "#{HEAD_RELEASE_URL}"
                   else
                     puts "Release type #{release_type} unknown!"
                     exit 1

--- a/bin/kubespray-integration.rb
+++ b/bin/kubespray-integration.rb
@@ -132,6 +132,7 @@ all:
     nodelocaldns_image_repo: gcr.io/google-containers/k8s-dns-node-cache
     dnsautoscaler_image_repo: gcr.io/google-containers/cluster-proportional-autoscaler-<%= @cluster_hash['k8s_infra']['arch'] %>
     kube_version: <%= @cluster_hash['k8s_infra']['k8s_release'] %>
+    kube_major_version: <%= @cluster_hash['k8s_infra']['stable_k8s_release'].split(".").take(2).join(".") %>
     etcd_deployment_type: host
     container_manager: containerd
     download_container: False

--- a/bin/kubespray-integration.rb
+++ b/bin/kubespray-integration.rb
@@ -30,7 +30,7 @@ class Kubespray
 
       #Check if binaries are available
       if cluster_hash['k8s_infra']['release_type'] == 'head' then
-        cluster_hash['k8s_infra']['hyperkube_download_url'] ="https://storage.googleapis.com/kubernetes-release-dev/ci-cross/#{cluster_hash['k8s_infra']['k8s_release']}/bin/linux/#{cluster_hash['k8s_infra']['arch']}/hyperkube"
+        cluster_hash['k8s_infra']['hyperkube_download_url'] ="https://storage.googleapis.com/kubernetes-release-dev/ci/#{cluster_hash['k8s_infra']['k8s_release']}/bin/linux/#{cluster_hash['k8s_infra']['arch']}/hyperkube"
       else
         cluster_hash['k8s_infra']['hyperkube_download_url'] ="https://storage.googleapis.com/kubernetes-release/release/#{cluster_hash['k8s_infra']['k8s_release']}/bin/linux/#{cluster_hash['k8s_infra']['arch']}/hyperkube"
       end

--- a/bin/kubespray-integration.rb
+++ b/bin/kubespray-integration.rb
@@ -30,14 +30,21 @@ class Kubespray
 
       #Check if binaries are available
       if cluster_hash['k8s_infra']['release_type'] == 'head' then
-        cluster_hash['k8s_infra']['hyperkube_download_url'] ="https://storage.googleapis.com/kubernetes-release-dev/ci/#{cluster_hash['k8s_infra']['k8s_release']}/bin/linux/#{cluster_hash['k8s_infra']['arch']}/hyperkube"
+        cluster_hash['k8s_infra']['kubelet_download_url'] ="https://storage.googleapis.com/kubernetes-release-dev/ci/#{cluster_hash['k8s_infra']['k8s_release']}/bin/linux/#{cluster_hash['k8s_infra']['arch']}/kubelet"
+        cluster_hash['k8s_infra']['kubectl_download_url'] ="https://storage.googleapis.com/kubernetes-release-dev/ci/#{cluster_hash['k8s_infra']['k8s_release']}/bin/linux/#{cluster_hash['k8s_infra']['arch']}/kubectl"
       else
-        cluster_hash['k8s_infra']['hyperkube_download_url'] ="https://storage.googleapis.com/kubernetes-release/release/#{cluster_hash['k8s_infra']['k8s_release']}/bin/linux/#{cluster_hash['k8s_infra']['arch']}/hyperkube"
+        cluster_hash['k8s_infra']['kubelet_download_url'] ="https://storage.googleapis.com/kubernetes-release/release/#{cluster_hash['k8s_infra']['k8s_release']}/bin/linux/#{cluster_hash['k8s_infra']['arch']}/kubelet"
+        cluster_hash['k8s_infra']['kubectl_download_url'] ="https://storage.googleapis.com/kubernetes-release/release/#{cluster_hash['k8s_infra']['k8s_release']}/bin/linux/#{cluster_hash['k8s_infra']['arch']}/kubectl"
       end
       cluster_hash['k8s_infra']['kubeadm_download_url'] ="https://storage.googleapis.com/kubernetes-release/release/#{cluster_hash['k8s_infra']['stable_k8s_release']}/bin/linux/#{cluster_hash['k8s_infra']['arch']}/kubeadm" 
-      cluster_hash['k8s_infra']['hyperkube_binary_checksum']= K8sUtils.k8s_sha(cluster_hash['k8s_infra']['hyperkube_download_url'])
-      if cluster_hash['k8s_infra']['hyperkube_binary_checksum'].nil? then
-        puts "hyperkube_binary_checksum is invalid" 
+      cluster_hash['k8s_infra']['kubelet_binary_checksum']= K8sUtils.k8s_sha(cluster_hash['k8s_infra']['kubelet_download_url'])
+      if cluster_hash['k8s_infra']['kubelet_binary_checksum'].nil? then
+        puts "kubelet_binary_checksum is invalid" 
+        exit 1
+      end
+      cluster_hash['k8s_infra']['kubectl_binary_checksum']= K8sUtils.k8s_sha(cluster_hash['k8s_infra']['kubectl_download_url'])
+      if cluster_hash['k8s_infra']['kubectl_binary_checksum'].nil? then
+        puts "kubectl_binary_checksum is invalid" 
         exit 1
       end
       cluster_hash['k8s_infra']['kubeadm_binary_checksum']= K8sUtils.k8s_sha(cluster_hash['k8s_infra']['kubeadm_download_url'])
@@ -122,9 +129,7 @@ class Kubespray
 all:
   vars: 
     ansible_ssh_common_args: '-o StrictHostKeyChecking=no'
-    <%- if @cluster_hash['k8s_infra']['release_type']=='head' and @cluster_hash['k8s_infra']['arch']=='amd64' -%>
-    kube_image_repo: docker.io/crosscloudci
-    <%- elsif @cluster_hash['k8s_infra']['release_type']=='head' and @cluster_hash['k8s_infra']['arch']=='arm64' -%>
+    <%- if @cluster_hash['k8s_infra']['release_type']=='head' -%>
     kube_image_repo: gcr.io/kubernetes-ci-images
     <%- else -%>
     kube_image_repo: gcr.io/google-containers
@@ -138,8 +143,10 @@ all:
     download_container: False
     kubeconfig_localhost: true
     kubectl_localhost: false
-    hyperkube_download_url: <%= @cluster_hash['k8s_infra']['hyperkube_download_url'] %> 
-    hyperkube_binary_checksum: <%= @cluster_hash['k8s_infra']['hyperkube_binary_checksum'] %>
+    kubelet_download_url: <%= @cluster_hash['k8s_infra']['kubelet_download_url'] %> 
+    kubelet_binary_checksum: <%= @cluster_hash['k8s_infra']['kubelet_binary_checksum'] %>
+    kubectl_download_url: <%= @cluster_hash['k8s_infra']['kubectl_download_url'] %> 
+    kubectl_binary_checksum: <%= @cluster_hash['k8s_infra']['kubectl_binary_checksum'] %>
     kubeadm_download_url: <%= @cluster_hash['k8s_infra']['kubeadm_download_url'] %>
     kubeadm_binary_checksum: <%= @cluster_hash['k8s_infra']['kubeadm_binary_checksum'] %>
     <%- if @cluster_hash['k8s_infra']['arch']=='amd64' -%>


### PR DESCRIPTION
## Description
1. Fix provisioning failures for Kubernetes HEAD

## Context
1. The upstream kubespray repo has switched away from hyperkube and is now using kubelet &
kubectl instead. This PR updates the integration to set the new download urls for both binaries.

2. The marker ci-cross/latest has now been deprecated, which means hyperkube artifacts are no longer available for head amd64/arm64.

Issues:

## How Has This Been Tested?
* [x]  Covered by existing integration testing
* [ ]  Added integration testing to cover
* [x] Tested with [trigger client](https://github.com/crosscloudci/crosscloudci-trigger) against 
   * [x] cidev.cncf.ci
   * [ ] dev.cncf.ci
   * [ ] staging.cncf.ci
   * [ ] cncf.ci (production)
* [x]  Tested locally
* [ ]  Have not tested

## Types of changes
* [x]  Bug fix (non-breaking change which fixes an issue)
* [ ]  New feature (non-breaking change which adds functionality)
* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
 
## Checklist:
* [ ]  My change requires a change to the documentation.
* [ ]  I have updated the documentation accordingly.
* [x] No updates required.