### PR TITLE
Dynamic update of Kubespray and K8s [#10]

### DIFF
--- a/bin/k8sinfra
+++ b/bin/k8sinfra
@@ -153,6 +153,10 @@ class K8sInfra < Thor
       if options['dry-run'] then
         puts "Dry-run successfully completed"
       else
+        if @cluster_hash['k8s_infra']["release_type"]=="kubespray" then
+	  latest = ks.latest_kubespray_release
+	  ks.update_kubespray(latest)
+        end
         cluster = ks.start_kubespray 
         if cluster[:exit_code] == 0 then
           puts "KUBECONFIG path: #{full_kubeconfig_path}"
@@ -233,8 +237,17 @@ class K8sInfra < Thor
       puts "All required options not handled"
     end
 
-    kubernetes_release = K8sUtils.kubernetes_release("#{options['release-type']}/#{options['arch']}")
-    stable_k8s_release = K8sUtils.kubernetes_release('stable')
+    unless options['release-type'] == "kubespray"
+      kubernetes_release = K8sUtils.kubernetes_release("#{options['release-type']}/#{options['arch']}")
+      stable_k8s_release = K8sUtils.kubernetes_release('stable')
+    else
+      ks = Kubespray.new(@cluster_hash)
+      ks_version = ks.latest_kubespray_release
+      k8s_version = ks.latest_supported_kubernetes(ks_version)
+      kubernetes_release = k8s_version + "\n"
+      stable_k8s_release = k8s_version + "\n"
+    end
+
     config = ERB.new(cluster_config_template("#{options['arch']}", "#{options['provision-type']}", "#{kubernetes_release}", "#{stable_k8s_release}", "#{options['release-type']}"), nil, '-')
     if options['output'] then
       if File.exist?(options['output']) then

--- a/bin/kubespray-integration.rb
+++ b/bin/kubespray-integration.rb
@@ -90,9 +90,6 @@ class Kubespray
     end
 
     commands = [ ]
-    ## Patch for Kubespray v2.12.* (1/2)
-    commands.push("git -C #{kubedir} checkout -- .")
-    ## End of Patch for Kubespray v2.12.* (1/2)
     commands.push("git -C #{kubedir} checkout master -q")
     commands.push("git -C #{kubedir} pull --all -q")
     commands.push("git -C #{kubedir} checkout tags/#{tag} -q")
@@ -106,20 +103,6 @@ class Kubespray
       end
     end
     puts "Kubespray updated to #{tag}"
-    ## Patch for Kubespray v2.12.* (2/2)
-    multfile='roles/kubernetes-apps/network_plugin/multus/tasks/main.yml'
-    oldtext = File.read("#{kubedir}/#{multfile}")
-    newtext = oldtext.gsub("item|skipped", "item is skipped")
-    File.open("#{kubedir}/#{multfile}", "w") {|file| file.puts newtext}
-    cnifile='roles/network_plugin/meta/main.yml'
-    oldtext = File.read("#{kubedir}/#{cnifile}")
-    newtext = oldtext.gsub(" == 'cni'", "_cni")
-    File.open("#{kubedir}/#{cnifile}", "w") {|file| file.puts newtext}
-    calicofile='roles/network_plugin/calico/templates/cni-calico.conflist.j2'
-    oldtext = File.read("#{kubedir}/#{calicofile}")
-    newtext = oldtext.gsub('"cniVersion":"0.3.1",', '"cniVersion":"0.2.0",')
-    File.open("#{kubedir}/#{calicofile}", "w") {|file| file.puts newtext}
-    ## End of Patch for Kubespray v2.12.* (2/2)
   end
 
   def start_kubespray
@@ -207,7 +190,6 @@ all:
     kubeconfig_localhost: true
     <%- if @cluster_hash['k8s_infra']['release_type']=='kubespray' -%>
     kube_network_plugin: calico
-    kube_network_plugin_cni: true
     kube_network_plugin_multus: true
     <%- end -%>
     kubectl_localhost: false


### PR DESCRIPTION
## Description
Adds dynamic update of Kubespray at provisioning stage.
The version will be the most recent release of Kubespray. In addition, the Kubernetes version is based on the most recent supported version in Kubespray.

The Kubernetes version is fetched during the `generate_config` stage, while Kubespray is updated in the `provision` stage.

To utilize the dynamic update, release type must be specified as "kubespray" when generating the configuration file
```
/k8s-infra/bin/k8sinfra generate_config (...) --release-type=kubespray (...)
```

In addition to the dynamic update, a few patches to the Kubespray code are also included.

## Context
With the existing image, the newest (stable) Kubernetes release is deployed. While this might be unofficially supported in the most recent Kubespray release, this cannot be guaranteed.

The changes are done based on observations in [CNF Testbed](https://github.com/cncf/cnf-testbed), which deploys Kubernetes with Multus and CNI plugins by default. Due to this, a small set of patches are included to the Kubespray code, when deploying with the "kubespray" release-type.

## Issues:
https://github.com/crosscloudci/k8s-infra/issues/10
https://github.com/cncf/cnf-testbed/issues/344
https://github.com/cncf/cnf-testbed/issues/345

## How Has This Been Tested?
* [ ]  Covered by existing integration testing
* [ ]  Added integration testing to cover
* [ ] Tested with [trigger client](https://github.com/crosscloudci/crosscloudci-trigger) against 
   * [ ] cidev.cncf.ci
   * [ ] dev.cncf.ci
   * [ ] staging.cncf.ci
   * [ ] cncf.ci (production)
* [x]  Tested locally
* [ ]  Have not tested

## Types of changes
* [x]  Bug fix (non-breaking change which fixes an issue)
* [x]  New feature (non-breaking change which adds functionality)
* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
 
## Checklist:
* [x]  My change requires a change to the documentation.
* [ ]  I have updated the documentation accordingly.
* [ ] No updates required.