### PR TITLE
Update dynamic update of Kubespray

### DIFF
--- a/bin/kubespray-integration.rb
+++ b/bin/kubespray-integration.rb
@@ -60,14 +60,14 @@ class Kubespray
   end
 
   def latest_kubespray_release
-    release_url = "https://api.github.com/repos/kubernetes-sigs/kubespray/releases/latest"
+    release_url = "https://api.github.com/repos/kubernetes-sigs/kubespray/tags"
     response = Faraday.get release_url
     if response.status != 200
       @logger.error "Failed to get Kubespray release info"
       exit 1
     end
     results = JSON.parse(response.body)
-    latest = results['tag_name']
+    latest = results[0]["name"]
     return "#{latest}"
   end
 


### PR DESCRIPTION
## Context
At this time the most recent Kubespray release is v2.13.2, but at the same time v2.12.7 was released, and looking at [Kubespray releases](https://github.com/kubernetes-sigs/kubespray/releases) it is seen that v2.12.7 is tagged as "Latest release", which causes the same issue that was previously fixed with a workaround, which was removed with the release of v2.13.

The proposed solution is to look at the list of tags instead of using the "latest" release tag, and select the first entry in this list.

## Issues:
None at this time

## How Has This Been Tested?
* [ ]  Covered by existing integration testing
* [ ]  Added integration testing to cover
* [ ] Tested with [trigger client](https://github.com/crosscloudci/crosscloudci-trigger) against 
   * [ ] cidev.cncf.ci
   * [ ] dev.cncf.ci
   * [ ] staging.cncf.ci
   * [ ] cncf.ci (production)
* [x]  Tested locally
* [ ]  Have not tested

## Types of changes
* [x]  Bug fix (non-breaking change which fixes an issue)
* [ ]  New feature (non-breaking change which adds functionality)
* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
 
## Checklist:
* [ ]  My change requires a change to the documentation.
* [ ]  I have updated the documentation accordingly.
* [x] No updates required.