### PR TITLE
gcr.io/google-containers url is now deprecated

### DIFF
--- a/bin/kubespray-integration.rb
+++ b/bin/kubespray-integration.rb
@@ -178,7 +178,7 @@ all:
     <%- if @cluster_hash['k8s_infra']['release_type']=='head' -%>
     kube_image_repo: gcr.io/kubernetes-ci-images
     <%- else -%>
-    kube_image_repo: gcr.io/google-containers
+    kube_image_repo: k8s.gcr.io
     <%- end -%>
     nodelocaldns_image_repo: gcr.io/google-containers/k8s-dns-node-cache
     dnsautoscaler_image_repo: gcr.io/google-containers/cluster-proportional-autoscaler-<%= @cluster_hash['k8s_infra']['arch'] %>


### PR DESCRIPTION
Adds support for the new image repo where K8s images are published for stable releases.