### PR TITLE
Add repo change from master to dynamic-kubespray-update

### DIFF
--- a/bin/kubespray-integration.rb
+++ b/bin/kubespray-integration.rb
@@ -178,7 +178,7 @@ all:
     <%- if @cluster_hash['k8s_infra']['release_type']=='head' -%>
     kube_image_repo: gcr.io/kubernetes-ci-images
     <%- else -%>
-    kube_image_repo: gcr.io/google-containers
+    kube_image_repo: k8s.gcr.io
     <%- end -%>
     nodelocaldns_image_repo: gcr.io/google-containers/k8s-dns-node-cache
     dnsautoscaler_image_repo: gcr.io/google-containers/cluster-proportional-autoscaler-<%= @cluster_hash['k8s_infra']['arch'] %>


### PR DESCRIPTION
Update is needed for the dynamic branch used by CNF Testbed.
Since branches will then be aligned, we can consider if the dynamic branch is still needed

The image on Docker hub (crosscloudci/k8s-infra:dynamic-kubespray-update) has already been updated to include the change and tested.