### PR TITLE
Workaround for issue with Multus and Kubespray

### DIFF
--- a/bin/kubespray-integration.rb
+++ b/bin/kubespray-integration.rb
@@ -191,6 +191,7 @@ all:
     <%- if @cluster_hash['k8s_infra']['release_type']=='kubespray' -%>
     kube_network_plugin: calico
     kube_network_plugin_multus: true
+    multus_cni_version: "0.3.1"
     <%- end -%>
     kubectl_localhost: false
     kubelet_download_url: <%= @cluster_hash['k8s_infra']['kubelet_download_url'] %> 


### PR DESCRIPTION
This workaround fixes the issue seen in https://github.com/cncf/cnf-testbed/issues/366

The change will step back the cni-version for Multus from 0.4.0 to 0.3.1. The change will only be applied when release_type is "kubespray", as used by CNF Testbed.

Has been tested "locally" on CNF Testbed K8s deployment (on Packet.com)