### PR TITLE
Fix bug with generate config not finding the latest supported k8s version

### DIFF
--- a/bin/kubespray-integration.rb
+++ b/bin/kubespray-integration.rb
@@ -72,7 +72,7 @@ class Kubespray
   end
 
   def latest_supported_kubernetes(tag)
-    version_url = "https://raw.githubusercontent.com/kubernetes-sigs/kubespray/#{tag}/roles/download/defaults/main.yml"
+    version_url = "https://raw.githubusercontent.com/kubernetes-sigs/kubespray/#{tag}/roles/kubespray-defaults/defaults/main.yaml"
     response = Faraday.get version_url
     if response.status != 200
       @logger.error "Failed to Kubespray raw file"


### PR DESCRIPTION
The kubespray folks moved the YAML config and renamed from yml to yaml as it's extension. This fixes that issue.